### PR TITLE
Update autograder-home path in assignment.edn

### DIFF
--- a/assignment.edn
+++ b/assignment.edn
@@ -4,4 +4,4 @@
   :autograder.client.handin/assignment-submission-url "https://sg2tkysai5.execute-api.us-east-1.amazonaws.com/dev/submit"
   :autograder.client.handin/sources                   ["src/"]
   :autograder.client.handin/assignment-home           "./"
-  :autograder.client.handin/autograder-home           "./.autograder/"}
+  :autograder.client.handin/autograder-home           "./"}


### PR DESCRIPTION
The `autograder-home` path references a non-existing path and causes the `AutoGrading` to fail with following excecption.
```
Exception in thread "main" java.io.FileNotFoundException: The Git repository at './.autograder/' could not be located.
	at clj_jgit.porcelain$load_repo.invokeStatic(porcelain.clj:68)
	at clj_jgit.porcelain$load_repo.invoke(porcelain.clj:57)
	at autograder.client.handin$asgn_git_repo.invokeStatic(handin.clj:99)
	at autograder.client.handin$asgn_git_repo.invoke(handin.clj:96)
	at autograder.client.handin$asgn_handin_patch.invokeStatic(handin.clj:170)
	at autograder.client.handin$asgn_handin_patch.invoke(handin.clj:164)
	at autograder.client.handin$submit_results.invokeStatic(handin.clj:283)
	at autograder.client.handin$submit_results.invoke(handin.clj:218)
	at autograder.client.handin$_submitResults.invokeStatic(handin.clj:305)
	at autograder.client.handin$_submitResults.invoke(handin.clj:304)
	at autograder.client.Handin.submitResults(Unknown Source)
	at org.magnum.dataup.AutoGradingSpec.grade(AutoGradingSpec.java:158)
	at org.magnum.dataup.AutoGrading.main(AutoGrading.java:64)
```